### PR TITLE
Adds a "Usage with Gatsby" section to the docs

### DIFF
--- a/docs/general-usage/index.rst
+++ b/docs/general-usage/index.rst
@@ -9,3 +9,4 @@ General Usage
     preview
     decorators
     hooks
+    usage-with-gatsby

--- a/docs/general-usage/usage-with-gatsby.rst
+++ b/docs/general-usage/usage-with-gatsby.rst
@@ -1,0 +1,10 @@
+
+Using Grapple with Gatsby
+=========================
+
+``wagtail-grapple`` provides a graphQL API to wagtail's contents, which can be accessed by a wide range of consumers.
+
+One very common use case is using Gatsby to fetch contents from Wagtail CMS then building and deploying a static site (developed in React).
+
+Frontend developers using Gatsby should check out `gatsby-source-wagtail <https://www.gatsbyjs.com/plugins/gatsby-source-wagtail/>`_, a plugin
+designed to interface directly with ``wagtail-grapple`` to streamline querying of wagtail.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,7 +50,7 @@ Features
   * :doc:`general-usage/graphql-types`
   * :doc:`general-usage/preview`
   * :doc:`general-usage/decorators`
-
+  * :doc:`general-usage/usage-with-gatsby`
 
 Contents
 ^^^^^^^^


### PR DESCRIPTION
Just a small section added to help developers find the frontend grapple plugin, per issue #138